### PR TITLE
Also pass file_path to the handler method

### DIFF
--- a/logshipper/tail.py
+++ b/logshipper/tail.py
@@ -121,7 +121,7 @@ class Tail(logshipper.input.BaseInput):
                 lines = lines[:-1]
 
             for line in lines:
-                self.handler({'message': line[:-1]})
+                self.handler(file_path=tail.path, line=line[:-1])
 
     def process_tail(self, path, should_seek=False):
         file_stat = os.stat(path)


### PR DESCRIPTION
With this change, we also pass file_path to the handler when a new line is detected.

This makes the whole thing more useful when monitoring / tailing multiple files. Previously it wasn't possible to know to which file the line refers to inside the handler function.

I also updated the handler method call to use keyword arguments instead of a dictionary. I know this is a breaking change, but it makes things more explicit and code more introspectable. 