### PR TITLE
Allow users to dynamically add new files and remove existing ones from the tailer

### DIFF
--- a/logshipper/tail.py
+++ b/logshipper/tail.py
@@ -77,12 +77,12 @@ class Tail(logshipper.input.BaseInput):
             self.add_file(filename=filename)
 
     def add_file(self, filename):
-        """
-        Add filename to the list of the monitored files.
+        """Add filename to the list of the monitored files.
 
         :param filename: Full absolute path to the file to monitor.
         :type filename: ``str``
         """
+
         full_path = os.path.abspath(filename)
 
         if full_path not in self.globs:
@@ -91,8 +91,7 @@ class Tail(logshipper.input.BaseInput):
         self.update_tails(self.globs, do_read_all=False)
 
     def remove_file(self, filename):
-        """
-        Remove filename from the list of the monitored files.
+        """Remove filename from the list of the monitored files.
 
         :param filename: Full absolute path to the file to remove.
         :type filename: ``str``

--- a/logshipper/test/test_context.py
+++ b/logshipper/test/test_context.py
@@ -56,7 +56,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(value, [1, "F 123"])
 
     def test_unknowntype(self):
-        class Foo():
+        class Foo(object):
             pass
 
         with self.assertRaises(TypeError):

--- a/logshipper/test/test_elasticsearch.py
+++ b/logshipper/test/test_elasticsearch.py
@@ -27,7 +27,7 @@ import logshipper.elasticsearch
 class Tests(unittest.TestCase):
 
     def test_elasticsearch_http(self):
-        class Foo():
+        class Foo(object):
             def __str__(self):
                 return "1235"
 

--- a/logshipper/test/test_filters.py
+++ b/logshipper/test/test_filters.py
@@ -158,12 +158,13 @@ class Tests(unittest.TestCase):
         handler = logshipper.filters.prepare_strptime({
             "field": "foo",
         })
+        now = datetime.datetime.now()
 
         message = {"foo": "Nov 13 01:22:22 CEST"}
         context = logshipper.context.Context(message, None)
         result = handler(message, context)
         self.assertEqual(result, None)
-        date = datetime.datetime(2014, 11, 13, 0, 22, 22, 0)
+        date = datetime.datetime(now.year, 11, 13, 0, 22, 22, 0)
         self.assertEqual(message['foo'], date)
 
     def test_strptime_parse(self):
@@ -171,7 +172,7 @@ class Tests(unittest.TestCase):
             "field": "foo",
         })
 
-        message = {"foo": "Nov 13 01:22:22"}
+        message = {"foo": "2014 Nov 13 01:22:22"}
         context = logshipper.context.Context(message, None)
         result = handler(message, context)
         self.assertEqual(result, None)


### PR DESCRIPTION
With this change user can now dynamically add new files and remove existing ones from the tailer during run time using `add_file` and `remove_file` methods respectively.

An alternative which is less flexible would be to instantiate new tailer instance every time user wants either to add or remove a monitored file.

We use this functionality inside our file watch StackStorm sensor (https://github.com/StackStorm/st2/blob/1a020ccceebf77c6c6c1ef2e07f55dee82733bd0/contrib/linux/sensors/file_watch_sensor.py#L35). We allow users to update a list of files which are monitored during the run time.

TODO:

- [x] Add tests